### PR TITLE
CHANGE(BMP-611): removed logs for unnecessary routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [BMP-611](https://makeitapp.atlassian.net/browse/BMP-611): added possibility to avoid logging for routes with specific prefixes. 
+In particular, status routes can now be stopped from logging incoming and completed request logs.
+
 ## 1.1.0 - 14-10-2020
 
 - [BMP-611](https://makeitapp.atlassian.net/browse/BMP-611): enabled logs for incoming and completed requests for all .NET services, modified logs to be more similar to other Mia-platform libraries.

--- a/MiaServiceDotNetLibrary/Logging/LoggingExtensions.cs
+++ b/MiaServiceDotNetLibrary/Logging/LoggingExtensions.cs
@@ -5,9 +5,10 @@ namespace MiaServiceDotNetLibrary.Logging
     public static class LoggingExtensions
     {
         public static IApplicationBuilder UseRequestResponseLoggingMiddleware(
-            this IApplicationBuilder builder)
+            this IApplicationBuilder builder, MiddlewareOptions options = default)
         {
-            return builder.UseMiddleware<RequestResponseLoggingMiddleware>();
+            options = options ?? new MiddlewareOptions();
+            return builder.UseMiddleware<RequestResponseLoggingMiddleware>(options);
         }
     }
 }

--- a/MiaServiceDotNetLibrary/Logging/RequestResponseLoggingMiddleware.cs
+++ b/MiaServiceDotNetLibrary/Logging/RequestResponseLoggingMiddleware.cs
@@ -12,7 +12,7 @@ namespace MiaServiceDotNetLibrary.Logging
 {
     public class MiddlewareOptions
 {
-    public List<string> excludedPrefixes { get; set; } = new List<string>();
+    public List<string> excludedPrefixes { get; set; } = new List<string>() {"/-/"};
 }
     public class RequestResponseLoggingMiddleware
     {
@@ -41,7 +41,7 @@ namespace MiaServiceDotNetLibrary.Logging
                     return;
                 }
             }
-            
+
             var responseStopwatch = new Stopwatch();
             responseStopwatch.Start();
 

--- a/MiaServiceDotNetLibrary/Logging/RequestResponseLoggingMiddleware.cs
+++ b/MiaServiceDotNetLibrary/Logging/RequestResponseLoggingMiddleware.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics;
 using System.IO;
 using System.Threading.Tasks;
+using System.Collections.Generic;
 using MiaServiceDotNetLibrary.Logging.Entities;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Extensions;
@@ -9,21 +10,38 @@ using log4net;
 
 namespace MiaServiceDotNetLibrary.Logging
 {
+    public class MiddlewareOptions
+{
+    public List<string> excludedPrefixes { get; set; } = new List<string>();
+}
     public class RequestResponseLoggingMiddleware
     {
         private readonly RequestDelegate _next;
+        private readonly MiddlewareOptions _options;
+
         internal static readonly string  RequestIdDictionaryKey = "requestId";
         internal static readonly string  RequestIdHeaderKey = "x-request-id";
         internal static readonly string  UserAgentHeaderKey = "User-Agent";
         internal static readonly string  ForwardedHostHeaderKey = "x-forwarded-host";
 
-        public RequestResponseLoggingMiddleware(RequestDelegate next)
+        public RequestResponseLoggingMiddleware(RequestDelegate next, MiddlewareOptions options)
         {
             _next = next;
+            _options = options;
         }
         
         public async Task Invoke(HttpContext context)
         {
+            string path = context.Request.Path;
+            foreach (string prefix in _options.excludedPrefixes)
+            {
+                if (path.StartsWith(prefix))
+                {
+                    await _next(context);
+                    return;
+                }
+            }
+            
             var responseStopwatch = new Stopwatch();
             responseStopwatch.Start();
 

--- a/MiaServiceDotNetLibrary/Logging/RequestResponseLoggingMiddleware.cs
+++ b/MiaServiceDotNetLibrary/Logging/RequestResponseLoggingMiddleware.cs
@@ -11,9 +11,10 @@ using log4net;
 namespace MiaServiceDotNetLibrary.Logging
 {
     public class MiddlewareOptions
-{
-    public List<string> excludedPrefixes { get; set; } = new List<string>() {"/-/"};
-}
+    {
+        public List<string> excludedPrefixes { get; set; } = new List<string>() {"/-/"};
+    }
+
     public class RequestResponseLoggingMiddleware
     {
         private readonly RequestDelegate _next;

--- a/MiaServiceDotNetLibrary/Logging/RequestResponseLoggingMiddleware.cs
+++ b/MiaServiceDotNetLibrary/Logging/RequestResponseLoggingMiddleware.cs
@@ -34,13 +34,10 @@ namespace MiaServiceDotNetLibrary.Logging
         public async Task Invoke(HttpContext context)
         {
             string path = context.Request.Path;
-            foreach (string prefix in _options.excludedPrefixes)
+            if (_options.excludedPrefixes.Exists(prefix => path.StartsWith(prefix)))
             {
-                if (path.StartsWith(prefix))
-                {
-                    await _next(context);
-                    return;
-                }
+                await _next(context);
+                return;
             }
 
             var responseStopwatch = new Stopwatch();

--- a/docs/Logging.md
+++ b/docs/Logging.md
@@ -25,7 +25,7 @@ app.UseRequestResponseLoggingMiddleware(new MiddlewareOptions {excludedPrefixes 
 ```
 
 The property `excludedPrefixes` is used to avoid logging incoming and completed request's logs for routes that should not show that kind of logs.  
-In particular, calling status routes should not generate any request related logs and, since all of them begin with the "/-/" prefix, we have excluded them using that property.
+In particular, calling status routes should not generate any request related logs and, since all of them begin with the "/-/" prefix, we have excluded them using this property.
 
 ## Example
 

--- a/docs/Logging.md
+++ b/docs/Logging.md
@@ -21,8 +21,11 @@ The library will generate two logs for each request, representing the incoming r
 To enable this logging functionality you should add the following line in the `Configure` function of `Startup.cs` file of your microservice:
 
 ```csharp
-app.UseRequestResponseLoggingMiddleware();
+app.UseRequestResponseLoggingMiddleware(new MiddlewareOptions {excludedPrefixes = new List<string>() { "/-/" }});
 ```
+
+The property `excludedPrefixes` is used to avoid logging incoming and completed request's logs for routes that should not show that kind of logs.  
+In particular, calling status routes should not generate any request related logs and, since all of them begin with the "/-/" prefix, we have excluded them using that property.
 
 ## Example
 

--- a/docs/Logging.md
+++ b/docs/Logging.md
@@ -6,7 +6,7 @@ There are two types of logging:
  * Request Logging: logs every request related message (incoming, completed and custom ones) with the standard Mia-Platform logging format.
  * Message Logging: logs a message, along with its custom properties if there are any.
 
-```
+```csharp
 // customObject attributes will be added to the log:
 Logger.Trace(HttpContext.Request, "message with object", customObject);
 // alternatively, without custom attributes:
@@ -21,7 +21,16 @@ The library will generate two logs for each request, representing the incoming r
 To enable this logging functionality you should add the following line in the `Configure` function of `Startup.cs` file of your microservice:
 
 ```csharp
-app.UseRequestResponseLoggingMiddleware(new MiddlewareOptions {excludedPrefixes = new List<string>() { "/-/" }});
+app.UseRequestResponseLoggingMiddleware();
+```
+
+The line above will automatically exclude status routes from logging but if you want to exclude some route prefixes from this logging functionality it is necessary to pass as a parameter a MiddlewareOptions instance:
+
+```csharp
+app.UseRequestResponseLoggingMiddleware(new MiddlewareOptions {
+  excludedPrefixes = new List<string>() { "/-/", "/RoutePrefixThatYouWantToExclude/" }
+  }
+);
 ```
 
 The property `excludedPrefixes` is used to avoid logging incoming and completed request's logs for routes that should not show that kind of logs.  

--- a/docs/Logging.md
+++ b/docs/Logging.md
@@ -29,8 +29,7 @@ The line above will automatically exclude status routes from logging but if you 
 ```csharp
 app.UseRequestResponseLoggingMiddleware(new MiddlewareOptions {
   excludedPrefixes = new List<string>() { "/-/", "/RoutePrefixThatYouWantToExclude/" }
-  }
-);
+});
 ```
 
 The property `excludedPrefixes` is used to avoid logging incoming and completed request's logs for routes that should not show that kind of logs.  


### PR DESCRIPTION
This PR makes it possible to specify which routes should not show incoming and completed request logs. By specifying a string prefix all routes that begins with said prefix will be excluded from showing incoming and completed request logs.

#### Checklist

[BMP-611](https://makeitapp.atlassian.net/browse/BMP-611)

- [ ] tests are included
- [X] the documentation is updated or integrated accordingly with your changes
- [X] the changelog has been updated accordingly with your changes
- [X] you are not committing extraneous files or sensible data
- [X] added the link to the Jira task
- [X] commit message and branch name conventions

#### Notify to

@fredmaggiowski 